### PR TITLE
add custom encoding registration function

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ ask the server to convert back and forth to/from this charset.
 
 If utf8 charset conversion is not supported on the server, and if the
 charset conversion is not supported by golang.org/x/text/encoding,
-client-side character set conversion will not be possible.
+you can add client-side character set conversion with the following code:
+
+	var e encoding.Encoding
+	tds.RegisterEncoding("name", e)
 
 You will have to handle it yourself and use a charset supported by the server.
 

--- a/doc.go
+++ b/doc.go
@@ -130,7 +130,10 @@ ask the server to convert back and forth to/from this charset.
 
 If utf8 charset conversion is not supported on the server, and if the
 charset conversion is not supported by golang.org/x/text/encoding,
-client-side character set conversion will not be possible.
+you can add client-side character set conversion with the following code:
+
+	var e encoding.Encoding
+	tds.RegisterEncoding("name", e)
 
 You will have to handle it yourself and use a charset supported by the server.
 


### PR DESCRIPTION
I'm new to golang.

This is experimental.

I hope somebody that advise if there is better way.

Fixes #6 

Usage Sample:

```
package foo

import (
	"github.com/axgle/mahonia"
	"golang.org/x/text/encoding"
	"golang.org/x/text/encoding/japanese"
	"golang.org/x/text/transform"
)

var ShiftJIS encoding.Encoding = &sjisEncoding{}

type sjisEncoding struct {
	encoding.Encoding
}

func (e *sjisEncoding) NewDecoder() *encoding.Decoder {
	return japanese.ShiftJIS.NewDecoder()
}

func (e *sjisEncoding) NewEncoder() *encoding.Encoder {
	return &encoding.Encoder{Transformer: &shiftJISEncoder{}}
}

type shiftJISEncoder struct{ transform.NopResetter }

// Transform using mahonia.
func (shiftJISEncoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
	encoder := mahonia.NewEncoder("sjis")
	encoded := []byte(encoder.ConvertString(string(src)))
	copy(dst, encoded)
	return nDst + len(encoded), nSrc + len(src), err
}
```

```
// override `sjis` encoding
tds.RegisterEncoding("sjis", foo.ShiftJIS)
```