### PR TITLE
Fix return error value when login fails

### DIFF
--- a/session.go
+++ b/session.go
@@ -207,7 +207,7 @@ loginResponse:
 	}
 
 	if s.state.err != nil && s.state.err != io.EOF {
-		return err
+		return s.state.err
 	}
 
 	// RSA encryption supported, extract the public key


### PR DESCRIPTION
At login failure the returned error is always nil and this creates a connection at sql.Open that is in an invalid state instead of reporting the sybase error that happened during the connection.

After the fix it returns the correct error value and the sql.Open call properly reports the error message